### PR TITLE
Namespaced category selectors

### DIFF
--- a/YYImage/YYAnimatedImageView.m
+++ b/YYImage/YYAnimatedImageView.m
@@ -188,7 +188,7 @@ typedef NS_ENUM(NSUInteger, YYAnimatedImageType) {
             
             if (miss) {
                 UIImage *img = [_curImage animatedImageFrameAtIndex:idx];
-                img = img.yy_imageByDecoded;
+                img = img.tnyy_imageByDecoded;
                 if ([self isCancelled]) break;
                 LOCK_VIEW(view->_buffer[@(idx)] = img ? img : [NSNull null]);
                 view = nil;

--- a/YYImage/YYFrameImage.m
+++ b/YYImage/YYFrameImage.m
@@ -74,7 +74,7 @@ static CGFloat _NSStringPathScale(NSString *string) {
     NSString *firstPath = paths[0];
     NSData *firstData = [NSData dataWithContentsOfFile:firstPath];
     CGFloat scale = _NSStringPathScale(firstPath);
-    UIImage *firstCG = [[[UIImage alloc] initWithData:firstData] yy_imageByDecoded];
+    UIImage *firstCG = [[[UIImage alloc] initWithData:firstData] tnyy_imageByDecoded];
     self = [self initWithCGImage:firstCG.CGImage scale:scale orientation:UIImageOrientationUp];
     if (!self) return nil;
     long frameByte = CGImageGetBytesPerRow(firstCG.CGImage) * CGImageGetHeight(firstCG.CGImage);
@@ -100,7 +100,7 @@ static CGFloat _NSStringPathScale(NSString *string) {
     
     NSData *firstData = dataArray[0];
     CGFloat scale = [UIScreen mainScreen].scale;
-    UIImage *firstCG = [[[UIImage alloc] initWithData:firstData] yy_imageByDecoded];
+    UIImage *firstCG = [[[UIImage alloc] initWithData:firstData] tnyy_imageByDecoded];
     self = [self initWithCGImage:firstCG.CGImage scale:scale orientation:UIImageOrientationUp];
     if (!self) return nil;
     long frameByte = CGImageGetBytesPerRow(firstCG.CGImage) * CGImageGetHeight(firstCG.CGImage);
@@ -138,11 +138,11 @@ static CGFloat _NSStringPathScale(NSString *string) {
         NSString *path = _imagePaths[index];
         CGFloat scale = _NSStringPathScale(path);
         NSData *data = [NSData dataWithContentsOfFile:path];
-        return [[UIImage imageWithData:data scale:scale] yy_imageByDecoded];
+        return [[UIImage imageWithData:data scale:scale] tnyy_imageByDecoded];
     } else if (_imageDatas) {
         if (index >= _imageDatas.count) return nil;
         NSData *data = _imageDatas[index];
-        return [[UIImage imageWithData:data scale:[UIScreen mainScreen].scale] yy_imageByDecoded];
+        return [[UIImage imageWithData:data scale:[UIScreen mainScreen].scale] tnyy_imageByDecoded];
     } else {
         return index == 0 ? self : nil;
     }

--- a/YYImage/YYImage.m
+++ b/YYImage/YYImage.m
@@ -162,7 +162,7 @@ static CGFloat _NSStringPathScale(NSString *string) {
             _bytesPerFrame = CGImageGetBytesPerRow(image.CGImage) * CGImageGetHeight(image.CGImage);
             _animatedImageMemorySize = _bytesPerFrame * decoder.frameCount;
         }
-        self.yy_isDecodedForDisplay = YES;
+        self.tnyy_isDecodedForDisplay = YES;
     }
     return self;
 }

--- a/YYImage/YYImageCoder.h
+++ b/YYImage/YYImageCoder.h
@@ -315,13 +315,13 @@ typedef NS_ENUM(NSUInteger, YYImageBlendOperation) {
  @return an image decoded, or just return itself if no needed.
  @see yy_isDecodedForDisplay
  */
-- (instancetype)yy_imageByDecoded;
+- (instancetype)tnyy_imageByDecoded;
 
 /**
  Wherher the image can be display on screen without additional decoding.
  @warning It just a hint for your code, change it has no other effect.
  */
-@property (nonatomic) BOOL yy_isDecodedForDisplay;
+@property (nonatomic) BOOL tnyy_isDecodedForDisplay;
 
 /**
  Saves this image to iOS Photos Album. 
@@ -334,7 +334,7 @@ typedef NS_ENUM(NSUInteger, YYImageBlendOperation) {
     assetURL: An URL that identifies the saved image file. If the image is not saved, assetURL is nil.
     error: If the image is not saved, an error object that describes the reason for failure, otherwise nil.
  */
-- (void)yy_saveToAlbumWithCompletionBlock:(nullable void(^)(NSURL * _Nullable assetURL, NSError * _Nullable error))completionBlock;
+- (void)tnyy_saveToAlbumWithCompletionBlock:(nullable void(^)(NSURL * _Nullable assetURL, NSError * _Nullable error))completionBlock;
 
 /**
  Return a 'best' data representation for this image.
@@ -345,7 +345,7 @@ typedef NS_ENUM(NSUInteger, YYImageBlendOperation) {
  
  @return Image data, or nil if an error occurs.
  */
-- (nullable NSData *)yy_imageDataRepresentation;
+- (nullable NSData *)tnyy_imageDataRepresentation;
 
 @end
 

--- a/YYImage/YYImageCoder.m
+++ b/YYImage/YYImageCoder.m
@@ -1657,7 +1657,7 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
         UIImage *image = [UIImage imageWithCGImage:imageRef scale:_scale orientation:_orientation];
         CFRelease(imageRef);
         if (!image) return nil;
-        image.yy_isDecodedForDisplay = decoded;
+        image.tnyy_isDecodedForDisplay = decoded;
         frame.image = image;
         return frame;
     }
@@ -1701,7 +1701,7 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
     CFRelease(imageRef);
     if (!image) return nil;
     
-    image.yy_isDecodedForDisplay = YES;
+    image.tnyy_isDecodedForDisplay = YES;
     frame.image = image;
     if (extendToCanvas) {
         frame.width = _width;
@@ -2776,8 +2776,8 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
 
 @implementation UIImage (YYImageCoder)
 
-- (instancetype)yy_imageByDecoded {
-    if (self.yy_isDecodedForDisplay) return self;
+- (instancetype)tnyy_imageByDecoded {
+    if (self.tnyy_isDecodedForDisplay) return self;
     CGImageRef imageRef = self.CGImage;
     if (!imageRef) return self;
     CGImageRef newImageRef = YYCGImageCreateDecodedCopy(imageRef, YES);
@@ -2785,21 +2785,21 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
     UIImage *newImage = [[self.class alloc] initWithCGImage:newImageRef scale:self.scale orientation:self.imageOrientation];
     CGImageRelease(newImageRef);
     if (!newImage) newImage = self; // decode failed, return self.
-    newImage.yy_isDecodedForDisplay = YES;
+    newImage.tnyy_isDecodedForDisplay = YES;
     return newImage;
 }
 
-- (BOOL)yy_isDecodedForDisplay {
+- (BOOL)tnyy_isDecodedForDisplay {
     if (self.images.count > 1 || [self isKindOfClass:[YYSpriteSheetImage class]]) return YES;
-    NSNumber *num = objc_getAssociatedObject(self, @selector(yy_isDecodedForDisplay));
+    NSNumber *num = objc_getAssociatedObject(self, @selector(tnyy_isDecodedForDisplay));
     return [num boolValue];
 }
 
-- (void)setYy_isDecodedForDisplay:(BOOL)isDecodedForDisplay {
-    objc_setAssociatedObject(self, @selector(yy_isDecodedForDisplay), @(isDecodedForDisplay), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+- (void)setTnyy_isDecodedForDisplay:(BOOL)isDecodedForDisplay {
+    objc_setAssociatedObject(self, @selector(tnyy_isDecodedForDisplay), @(isDecodedForDisplay), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (void)yy_saveToAlbumWithCompletionBlock:(void(^)(NSURL *assetURL, NSError *error))completionBlock {
+- (void)tnyy_saveToAlbumWithCompletionBlock:(void(^)(NSURL *assetURL, NSError *error))completionBlock {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSData *data = [self _yy_dataRepresentationForSystem:YES];
         ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
@@ -2816,7 +2816,7 @@ CGImageRef YYCGImageCreateWithWebPData(CFDataRef webpData,
     });
 }
 
-- (NSData *)yy_imageDataRepresentation {
+- (NSData *)tnyy_imageDataRepresentation {
     return [self _yy_dataRepresentationForSystem:NO];
 }
 


### PR DESCRIPTION
The UIImage category selectors in YYImageCoder can easily conflict with any other dynamically loaded library which uses the same functions, because they’re only namespaced using “yy_”. Since this is the TextNow-specific fork of YYImage, this commit adds “tn” to the start of those selector names.